### PR TITLE
OPS-2514 mentions the boto3 and botocore packages as role requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This role handles the creation of AWS VPC's
 ## Requirements
 
 * Ansible 2.5
+* [botocore](https://pypi.org/project/botocore/)
+* [boto3](https://pypi.org/project/boto3/)
 
 
 ## Additional variables


### PR DESCRIPTION
People need to be aware of the role's requirements upfront.
My follow-up proposal would be to install the AWS-related prerequisites in special-purposed Docker images, which we can later use for tests or deployments containers.